### PR TITLE
Fix after NIJZ change queries

### DIFF
--- a/cepimose/__init__.py
+++ b/cepimose/__init__.py
@@ -14,6 +14,7 @@ from .data import (
     _vaccinations_timestamp_req,
     _vaccinations_age_group_by_region_on_day_requests,
     _vaccination_by_manufacturer_supplied_used_requests,
+    _vaccinations_by_manufacturer_used_req,
 )
 from .parser import (
     _parse_vaccinations_by_age,
@@ -28,6 +29,7 @@ from .parser import (
     _parse_vaccinations_timestamp,
     _parse_vaccinations_age_group_by_region_on_day,
     _parse_vaccinations_by_manufacturer_supplied_used,
+    _parse_vaccinations_by_manufacturer_used,
 )
 
 from .types import (
@@ -190,3 +192,9 @@ def vaccinations_by_manufacturer_supplied_used(
     req = _vaccination_by_manufacturer_supplied_used_requests[group][0]
     doses = _get_data(req, _parse_vaccinations_by_manufacturer_supplied_used)
     return doses
+
+
+def vaccinations_by_manufacturer_used() -> "list[VaccinationByManufacturerRow]":
+    return _get_data(
+        _vaccinations_by_manufacturer_used_req, _parse_vaccinations_by_manufacturer_used
+    )

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -24,6 +24,21 @@ _models = {
             "Sources": [{"ReportId": "dddc4907-41d2-4b6c-b34b-3aac90b7fdee"}],
         },
     },
+    "ver3": {
+        "headers": {
+            "X-PowerBI-ResourceKey": "ad74a553-ebd2-476f-ab42-d79b590dd8c2",
+        },
+        "modelId": 175575,
+        "ApplicationContext": {
+            "DatasetId": "51c64860-e9ec-49d8-8a36-743bced78e1a",
+            "Sources": [
+                {
+                    "ReportId": "dddc4907-41d2-4b6c-b34b-3aac90b7fdee",
+                    "VisualId": "022fd838583336ee7f55",
+                }
+            ],
+        },
+    },
 }
 
 
@@ -38,7 +53,7 @@ def _get_model_version(ver):
     }
 
 
-_model_ver = _get_model_version("ver2")
+_model_ver = _get_model_version("ver3")
 
 _headers = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:87.0) Gecko/20100101 Firefox/87.0",
@@ -1429,7 +1444,7 @@ _vaccinations_by_municipalities_share_command = {
         "Query": {
             "Version": 2,
             "From": [
-                {"Name": "e", "Entity": "eRCO_podatki_obcine_pop", "Type": 0},
+                {"Name": "e", "Entity": "eRCO_podatki_občine", "Type": 0},
                 {"Name": "s", "Entity": "xls_SURS_obcine", "Type": 0},
                 {"Name": "c", "Entity": "Calendar", "Type": 0},
             ],
@@ -1440,13 +1455,6 @@ _vaccinations_by_municipalities_share_command = {
                         "Property": "Obcina",
                     },
                     "Name": "SURS_obcine.Obcina",
-                },
-                {
-                    "Measure": {
-                        "Expression": {"SourceRef": {"Source": "e"}},
-                        "Property": "Odst_Obcina_1_1",
-                    },
-                    "Name": "eRCO_podatki_obcine.Odst_PrviOdmerek",
                 },
                 {
                     "Aggregation": {
@@ -1463,9 +1471,40 @@ _vaccinations_by_municipalities_share_command = {
                 {
                     "Measure": {
                         "Expression": {"SourceRef": {"Source": "e"}},
-                        "Property": "Odst_Obcina_2",
+                        "Property": "Odst_CelotnaSLO_P",
                     },
-                    "Name": "eRCO_podatki_obcine_pop.Odst_Obcina_2",
+                    "Name": "eRCO_podatki_obcine_pop.Odst_CelotnaSLO_P",
+                },
+                {
+                    "Measure": {
+                        "Expression": {"SourceRef": {"Source": "e"}},
+                        "Property": "Odst_CelotnaSLO_C",
+                    },
+                    "Name": "eRCO_podatki_obcine_pop.Odst_CelotnaSLO_C",
+                },
+                {
+                    "Aggregation": {
+                        "Expression": {
+                            "Column": {
+                                "Expression": {"SourceRef": {"Source": "e"}},
+                                "Property": "Cepljeni​",
+                            }
+                        },
+                        "Function": 0,
+                    },
+                    "Name": "Sum(eRCO_podatki_občine.Cepljeni​)",
+                },
+                {
+                    "Aggregation": {
+                        "Expression": {
+                            "Column": {
+                                "Expression": {"SourceRef": {"Source": "e"}},
+                                "Property": "Polno ﻿Cepljeni",
+                            }
+                        },
+                        "Function": 0,
+                    },
+                    "Name": "Sum(eRCO_podatki_občine.PolnöCepljeni)",
                 },
             ],
             "Where": [
@@ -1520,17 +1559,17 @@ _vaccinations_by_municipalities_share_command = {
                     "Expression": {
                         "Measure": {
                             "Expression": {"SourceRef": {"Source": "e"}},
-                            "Property": "Odst_Obcina_2",
+                            "Property": "Odst_CelotnaSLO_P",
                         }
                     },
                 }
             ],
         },
         "Binding": {
-            "Primary": {"Groupings": [{"Projections": [0, 1, 2, 3]}]},
+            "Primary": {"Groupings": [{"Projections": [0, 1, 2, 3, 4, 5]}]},
             "DataReduction": {"DataVolume": 4, "Primary": {"Top": {}}},
-            "Aggregates": [{"Select": 3, "Aggregations": [{"Min": {}}, {"Max": {}}]}],
-            "SuppressedJoinPredicates": [1, 2],
+            "Aggregates": [{"Select": 2, "Aggregations": [{"Min": {}}, {"Max": {}}]}],
+            "SuppressedJoinPredicates": [1, 3, 4, 5],
             "Version": 1,
         },
         "ExecutionMetricsKind": 1,

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -266,7 +266,7 @@ def _get_default_by_region_by_day_command():
                 "Version": 2,
                 "From": [
                     {"Name": "c1", "Entity": "Calendar", "Type": 0},
-                    {"Name": "c", "Entity": "eRCO_podatki_ed", "Type": 0},
+                    {"Name": "c", "Entity": "eRCO_​​podatki", "Type": 0},
                     {"Name": "s", "Entity": "Sifrant_regija", "Type": 0},
                 ],
                 "Select": [
@@ -285,11 +285,11 @@ def _get_default_by_region_by_day_command():
                         "Name": "eRCO_podatki.Weight running total in Date",
                     },
                     {
-                        "Column": {
+                        "Measure": {
                             "Expression": {"SourceRef": {"Source": "c"}},
-                            "Property": "Odmerek",
+                            "Property": "Tekoča vsota za mero Precepljenost v polju Date",
                         },
-                        "Name": "eRCO_podatki.Odmerek",
+                        "Name": "eRCO_podatki_ed.Tekoča vsota za mero Precepljenost v polju Date",
                     },
                 ],
                 "Where": [
@@ -336,12 +336,8 @@ def _get_default_by_region_by_day_command():
                 ],
             },
             "Binding": {
-                "Primary": {"Groupings": [{"Projections": [0, 1]}]},
-                "Secondary": {"Groupings": [{"Projections": [2]}]},
-                "DataReduction": {
-                    "DataVolume": 4,
-                    "Intersection": {"BinnedLineSample": {}},
-                },
+                "Primary": {"Groupings": [{"Projections": [0, 1, 2]}]},
+                "DataReduction": {"DataVolume": 4, "Primary": {"BinnedLineSample": {}}},
                 "Version": 1,
             },
             "ExecutionMetricsKind": 1,

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -875,70 +875,60 @@ _vaccinations_by_day_command = {
 
 _vaccinations_by_age_command = {
     "SemanticQueryDataShapeCommand": {
-        "Binding": {
-            "DataReduction": {
-                "DataVolume": 4,
-                "Primary": {"Window": {"Count": 200}},
-                "Secondary": {"Top": {"Count": 60}},
-            },
-            "Primary": {"Groupings": [{"Projections": [0, 1, 3]}]},
-            "Secondary": {"Groupings": [{"Projections": [2]}]},
-            "SuppressedJoinPredicates": [3],
-            "Version": 1,
-        },
         "Query": {
+            "Version": 2,
             "From": [
-                {"Entity": "eRCO_podatki_ed", "Name": "e", "Type": 0},
-                {"Entity": "xls_SURS_starost", "Name": "s", "Type": 0},
-                {"Entity": "Calendar", "Name": "c", "Type": 0},
-            ],
-            "OrderBy": [
-                {
-                    "Direction": 1,
-                    "Expression": {
-                        "Column": {
-                            "Expression": {"SourceRef": {"Source": "s"}},
-                            "Property": "Starostni razred",
-                        }
-                    },
-                }
+                {"Name": "s", "Entity": "xls_SURS_starost", "Type": 0},
+                {"Name": "e", "Entity": "eRCO_​​podatki", "Type": 0},
+                {"Name": "c", "Entity": "Calendar", "Type": 0},
             ],
             "Select": [
                 {
                     "Column": {
                         "Expression": {"SourceRef": {"Source": "s"}},
-                        "Property": "Starostni razred",
+                        "Property": "Starostni ​razred",
                     },
-                    "Name": "xls_SURS_starost.Starostni razred",
+                    "Name": "SURS_starost.Starostni razred",
                 },
                 {
                     "Measure": {
                         "Expression": {"SourceRef": {"Source": "e"}},
-                        "Property": "Delež_starost",
+                        "Property": "Delež_starost_precepljenost",
                     },
-                    "Name": "eRCO_podatki.Delež_starost",
+                    "Name": "eRCO_podatki_ed.Delež_starost_precepljenost",
                 },
                 {
-                    "Column": {
+                    "Measure": {
                         "Expression": {"SourceRef": {"Source": "e"}},
-                        "Property": "Odmerek",
+                        "Property": "Delež_starost_1",
                     },
-                    "Name": "eRCO_podatki.Odmerek",
+                    "Name": "eRCO_podatki_ed.Delež_starost",
                 },
                 {
                     "Aggregation": {
                         "Expression": {
                             "Column": {
                                 "Expression": {"SourceRef": {"Source": "e"}},
-                                "Property": "Weight",
+                                "Property": "Odmerek – kopija",
                             }
                         },
                         "Function": 0,
                     },
-                    "Name": "Sum(eRCO_podatki.Weight)",
+                    "Name": "Sum(eRCO_​​podatki.Odmerek – kopija)",
+                },
+                {
+                    "Aggregation": {
+                        "Expression": {
+                            "Column": {
+                                "Expression": {"SourceRef": {"Source": "e"}},
+                                "Property": "Precepljenost",
+                            }
+                        },
+                        "Function": 0,
+                    },
+                    "Name": "Sum(eRCO_​​podatki.Precepljenost)",
                 },
             ],
-            "Version": 2,
             "Where": [
                 {
                     "Condition": {
@@ -985,7 +975,25 @@ _vaccinations_by_age_command = {
                     }
                 },
             ],
+            "OrderBy": [
+                {
+                    "Direction": 1,
+                    "Expression": {
+                        "Column": {
+                            "Expression": {"SourceRef": {"Source": "s"}},
+                            "Property": "Starostni ​razred",
+                        }
+                    },
+                }
+            ],
         },
+        "Binding": {
+            "Primary": {"Groupings": [{"Projections": [0, 1, 2, 3, 4]}]},
+            "DataReduction": {"DataVolume": 4, "Primary": {"Window": {"Count": 1000}}},
+            "SuppressedJoinPredicates": [3, 4],
+            "Version": 1,
+        },
+        "ExecutionMetricsKind": 1,
     }
 }
 

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -1575,6 +1575,104 @@ _vaccinations_by_municipalities_share_command = {
     }
 }
 
+_vaccinations_by_manufacturer_used_command = {
+    "SemanticQueryDataShapeCommand": {
+        "Query": {
+            "Version": 2,
+            "From": [
+                {"Name": "c1", "Entity": "Calendar", "Type": 0},
+                {"Name": "s", "Entity": "Sifrant_Cepivo", "Type": 0},
+                {"Name": "c", "Entity": "eRCO_​​podatki", "Type": 0},
+            ],
+            "Select": [
+                {
+                    "Column": {
+                        "Expression": {"SourceRef": {"Source": "c1"}},
+                        "Property": "Date",
+                    },
+                    "Name": "Calendar.Date",
+                },
+                {
+                    "Column": {
+                        "Expression": {"SourceRef": {"Source": "s"}},
+                        "Property": "Cepivo_Ime",
+                    },
+                    "Name": "Sifrant_Cepivo.Cepivo_Ime",
+                },
+                {
+                    "Aggregation": {
+                        "Expression": {
+                            "Column": {
+                                "Expression": {"SourceRef": {"Source": "c"}},
+                                "Property": "Weight",
+                            }
+                        },
+                        "Function": 0,
+                    },
+                    "Name": "Sum(eRCO_podatki_ed.Weight)",
+                },
+            ],
+            "Where": [
+                {
+                    "Condition": {
+                        "Comparison": {
+                            "ComparisonKind": 2,
+                            "Left": {
+                                "Column": {
+                                    "Expression": {"SourceRef": {"Source": "c1"}},
+                                    "Property": "Date",
+                                }
+                            },
+                            "Right": {
+                                "DateSpan": {
+                                    "Expression": {
+                                        "Literal": {
+                                            "Value": "datetime'2020-12-26T00:00:00'"
+                                        }
+                                    },
+                                    "TimeUnit": 5,
+                                }
+                            },
+                        }
+                    }
+                },
+                {
+                    "Condition": {
+                        "Not": {
+                            "Expression": {
+                                "In": {
+                                    "Expressions": [
+                                        {
+                                            "Column": {
+                                                "Expression": {
+                                                    "SourceRef": {"Source": "s"}
+                                                },
+                                                "Property": "Cepivo_Ime",
+                                            }
+                                        }
+                                    ],
+                                    "Values": [[{"Literal": {"Value": "null"}}]],
+                                }
+                            }
+                        }
+                    }
+                },
+            ],
+        },
+        "Binding": {
+            "Primary": {"Groupings": [{"Projections": [0, 2]}]},
+            "Secondary": {"Groupings": [{"Projections": [1]}]},
+            "DataReduction": {
+                "DataVolume": 4,
+                "Primary": {"Sample": {}},
+                "Secondary": {"Top": {}},
+            },
+            "Version": 1,
+        },
+        "ExecutionMetricsKind": 1,
+    }
+}
+
 
 # REQ
 _vaccinations_timestamp_req = _create_req([_vaccinations_timestamp_command])
@@ -1609,4 +1707,8 @@ _vaccinations_age_group_by_region_on_day_requests = (
 
 _vaccination_by_manufacturer_supplied_used_requests = (
     _create_vaccination_by_manufacturer_used_requests()
+)
+
+_vaccinations_by_manufacturer_used_req = _create_req(
+    [_vaccinations_by_manufacturer_used_command]
 )

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -809,19 +809,11 @@ _vaccinations_timestamp_command = {
 
 _vaccinations_by_day_command = {
     "SemanticQueryDataShapeCommand": {
-        "Binding": {
-            "DataReduction": {
-                "DataVolume": 4,
-                "Intersection": {"BinnedLineSample": {}},
-            },
-            "Primary": {"Groupings": [{"Projections": [0, 1]}]},
-            "Secondary": {"Groupings": [{"Projections": [2]}]},
-            "Version": 1,
-        },
         "Query": {
+            "Version": 2,
             "From": [
-                {"Entity": "Calendar", "Name": "c1", "Type": 0},
-                {"Entity": "eRCO_podatki_ed", "Name": "c", "Type": 0},
+                {"Name": "c1", "Entity": "Calendar", "Type": 0},
+                {"Name": "c", "Entity": "eRCO_​​podatki", "Type": 0},
             ],
             "Select": [
                 {
@@ -839,14 +831,13 @@ _vaccinations_by_day_command = {
                     "Name": "eRCO_podatki.Weight running total in Date",
                 },
                 {
-                    "Column": {
+                    "Measure": {
                         "Expression": {"SourceRef": {"Source": "c"}},
-                        "Property": "Odmerek",
+                        "Property": "Tekoča vsota za mero Precepljenost v polju Date",
                     },
-                    "Name": "eRCO_podatki.Odmerek",
+                    "Name": "eRCO_podatki_ed.Tekoča vsota za mero Precepljenost v polju Date",
                 },
             ],
-            "Version": 2,
             "Where": [
                 {
                     "Condition": {
@@ -873,6 +864,12 @@ _vaccinations_by_day_command = {
                 }
             ],
         },
+        "Binding": {
+            "Primary": {"Groupings": [{"Projections": [0, 1, 2]}]},
+            "DataReduction": {"DataVolume": 4, "Primary": {"BinnedLineSample": {}}},
+            "Version": 1,
+        },
+        "ExecutionMetricsKind": 1,
     }
 }
 

--- a/cepimose/data.py
+++ b/cepimose/data.py
@@ -999,19 +999,12 @@ _vaccinations_by_age_command = {
 
 _vaccinations_supplied_and_used_command = {
     "SemanticQueryDataShapeCommand": {
-        "Binding": {
-            "DataReduction": {
-                "DataVolume": 4,
-                "Primary": {"BinnedLineSample": {}},
-            },
-            "Primary": {"Groupings": [{"Projections": [0, 1, 2]}]},
-            "Version": 1,
-        },
         "Query": {
+            "Version": 2,
             "From": [
-                {"Entity": "Calendar", "Name": "c1", "Type": 0},
-                {"Entity": "eRCO_podatki_ed", "Name": "c", "Type": 0},
-                {"Entity": "xls_NIJZ_Odmerki", "Name": "n", "Type": 0},
+                {"Name": "c1", "Entity": "Calendar", "Type": 0},
+                {"Name": "c", "Entity": "eRCO_​​podatki", "Type": 0},
+                {"Name": "n", "Entity": "xls_NIJZ_Odmerki", "Type": 0},
             ],
             "Select": [
                 {
@@ -1031,12 +1024,11 @@ _vaccinations_supplied_and_used_command = {
                 {
                     "Measure": {
                         "Expression": {"SourceRef": {"Source": "n"}},
-                        "Property": "Tekoča vsota za mero odmerki* v polju Date",
+                        "Property": "Tekoča vsota za mero odmerki*​ v polju Date",
                     },
                     "Name": "NIJZ_Odmerki.Tekoča vsota za mero odmerki* v polju Date",
                 },
             ],
-            "Version": 2,
             "Where": [
                 {
                     "Condition": {
@@ -1063,6 +1055,12 @@ _vaccinations_supplied_and_used_command = {
                 }
             ],
         },
+        "Binding": {
+            "Primary": {"Groupings": [{"Projections": [0, 1, 2]}]},
+            "DataReduction": {"DataVolume": 4, "Primary": {"BinnedLineSample": {}}},
+            "Version": 1,
+        },
+        "ExecutionMetricsKind": 1,
     }
 }
 

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -98,11 +98,18 @@ def _parse_vaccinations_by_age(data) -> "list[VaccinationByAgeRow]":
 
 
 def _parse_vaccines_supplied_and_used(data) -> "list[VaccineSupplyUsage]":
+    if "DS" not in data["results"][0]["result"]["data"]["dsr"]:
+        error = data["results"][0]["result"]["data"]["dsr"]["DataShapes"][0][
+            "odata.error"
+        ]
+        print(error)
+        raise Exception("Something went wrong!")
+
     resp = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
     parsed_data = []
 
     for element in resp:
-
+        print(element)
         date = parse_date(element["C"][0])
 
         if "Ø" in element:

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -67,15 +67,22 @@ def _parse_vaccinations_by_day(data) -> "list[VaccinationByDayRow]":
 
 
 def _parse_vaccinations_by_age(data) -> "list[VaccinationByAgeRow]":
+    if "DS" not in data["results"][0]["result"]["data"]["dsr"]:
+        error = data["results"][0]["result"]["data"]["dsr"]["DataShapes"][0][
+            "odata.error"
+        ]
+        print(error)
+        raise Exception("Something went wrong!")
     resp = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
     parsed_data = []
 
     for element in resp:
-        age_group = str(element["G0"])
-        count_first = int(element["X"][0]["C"][1])
-        count_second = int(element["X"][1]["C"][1])
-        share_first = float(element["X"][0]["C"][0]) / 100.0
-        share_second = float(element["X"][1]["C"][0]) / 100.0
+        C = element["C"]
+        age_group = str(C[0])
+        share_second = float(C[1]) / 100.0
+        share_first = float(C[2]) / 100.0
+        count_second = int(C[3])
+        count_first = int(C[4])
 
         parsed_data.append(
             VaccinationByAgeRow(

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -428,3 +428,50 @@ def _parse_vaccinations_by_manufacturer_supplied_used(
             raise Exception("Unknown [C] length")
 
     return parsed_data
+
+
+def _parse_vaccinations_by_manufacturer_used(
+    data,
+) -> "list[VaccinationByManufacturerRow]":
+    if "DS" not in data["results"][0]["result"]["data"]["dsr"]:
+        error = data["results"][0]["result"]["data"]["dsr"]["DataShapes"][0][
+            "odata.error"
+        ]
+        print(error)
+        raise Exception("Something went wrong!")
+
+    resp = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
+
+    parsed_data = []
+    for element in resp:
+        elements = list(filter(lambda x: "M0" in x, element["X"]))
+
+        date = parse_date(element["G0"])
+        moderna = None
+        pfizer = None
+        az = None
+        janssen = None
+
+        if len(elements) == 4:
+            moderna = int(elements[0]["M0"])
+            janssen = int(elements[1]["M0"])
+            az = int(elements[2]["M0"])
+            pfizer = int(elements[3]["M0"])
+        else:
+            for el in elements:
+                if el.get("I", None) == 1:
+                    janssen = int(el["M0"])
+                elif el.get("I", None) == 2:
+                    moderna = int(el["M0"])
+                elif el.get("I", None) == 3:
+                    pfizer = int(el["M0"])
+                else:
+                    az = int(el["M0"])
+
+        parsed_data.append(
+            VaccinationByManufacturerRow(
+                date=date, pfizer=pfizer, moderna=moderna, az=az, janssen=janssen
+            )
+        )
+
+    return parsed_data

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -305,26 +305,13 @@ def _parse_vaccinations_by_region_by_day(data):
     resp = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
     parsed_data = []
 
-    r_list = [None, 1]
-
     people_vaccinated = None
     people_fully_vaccinated = None
     for element in resp:
-        date = parse_date(element["G0"])
-
-        R = element["X"][0]["R"] if "R" in element["X"][0] else None
-
-        if R == None:
-            people_vaccinated = element["X"][0]["M0"]
-            people_fully_vaccinated = (
-                element["X"][1]["M0"] if len(element["X"]) > 1 else 0
-            )
-
-        if R == 1:
-            # as far as we know people_vaccinated same as previous
-            people_fully_vaccinated = (
-                element["X"][1]["M0"] if len(element["X"]) > 1 else 0
-            )
+        C = element["C"]
+        date = parse_date(C[0])
+        people_vaccinated = C[1] if len(C) >= 2 else people_vaccinated
+        people_fully_vaccinated = C[2] if len(C) >= 3 else people_fully_vaccinated
 
         parsed_data.append(
             VaccinationByDayRow(

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -316,10 +316,7 @@ def _parse_vaccinations_by_municipalities_share(data) -> "list[VaccinationMunSha
     parsed_data = []
 
     for el in resp:
-        name, share1, population, share2 = el["C"]
-        print(name, share1, population, share2, sep="\t")
-        dose1 = round(int(population) * float(share1))
-        dose2 = round(int(population) * float(share2))
+        name, population, share2, share1, dose1, dose2 = el["C"]
         parsed_data.append(
             VaccinationMunShare(
                 name=name,
@@ -369,7 +366,7 @@ def _parse_vaccinations_age_group_by_region_on_day(
                 total_share=float(item[0]),
                 total_count=item[1],
             )
-        raise Exception('Unknown item length!')
+        raise Exception("Unknown item length!")
 
     parsed_data = []
     for el in resp:

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -29,13 +29,31 @@ def _parse_vaccinations_timestamp(data):
 
 
 def _parse_vaccinations_by_day(data) -> "list[VaccinationByDayRow]":
+    if "DS" not in data["results"][0]["result"]["data"]["dsr"]:
+        error = data["results"][0]["result"]["data"]["dsr"]["DataShapes"][0][
+            "odata.error"
+        ]
+        print(error)
+        raise Exception("Something went wrong!")
     resp = data["results"][0]["result"]["data"]["dsr"]["DS"][0]["PH"][0]["DM0"]
     parsed_data = []
 
+    date = None
+    people_vaccinated = None
+    people_fully_vaccinated = None
     for element in resp:
-        date = parse_date(element["G0"])
-        people_vaccinated = element["X"][0]["M0"]
-        people_fully_vaccinated = element["X"][1]["M0"] if len(element["X"]) > 1 else 0
+        C = element["C"]
+        if len(C) == 3:
+            date = parse_date(C[0])
+            people_vaccinated = C[1]
+            people_fully_vaccinated = C[2]
+        elif len(C) == 2:
+            date = parse_date(C[0])
+            people_vaccinated = C[1]
+        elif len(C) == 1:
+            date = parse_date(C[0])
+        else:
+            raise Exception("Unknown item length!")
 
         parsed_data.append(
             VaccinationByDayRow(

--- a/cepimose/parser.py
+++ b/cepimose/parser.py
@@ -81,8 +81,8 @@ def _parse_vaccinations_by_age(data) -> "list[VaccinationByAgeRow]":
         age_group = str(C[0])
         share_second = float(C[1]) / 100.0
         share_first = float(C[2]) / 100.0
-        count_second = int(C[3])
-        count_first = int(C[4])
+        count_first = int(C[3])
+        count_second = int(C[4])
 
         parsed_data.append(
             VaccinationByAgeRow(

--- a/test/test.py
+++ b/test/test.py
@@ -30,6 +30,8 @@ class CepimoseTestCase(unittest.TestCase):
         #! NIJZ is changing data tests could fail in the future
         assertRow(data[9], datetime.datetime(2021, 1, 5), 15711, 0)
         assertRow(data[22], datetime.datetime(2021, 1, 18), 48745, 315)
+        assertRow(data[41], datetime.datetime(2021, 2, 6), 56066, 44924)
+        assertRow(data[42], datetime.datetime(2021, 2, 7), 56066, 44924)
 
         self.assertDatesIncreaseSince(data, datetime.datetime(2020, 12, 27))
 

--- a/test/test.py
+++ b/test/test.py
@@ -330,3 +330,19 @@ class CepimoseTestCase(unittest.TestCase):
                 test_item["used"],
             )
             # ? more assertions
+
+    def test_vaccinations_by_manufacturer_used(self):
+        data = cepimose.vaccinations_by_manufacturer_used()
+
+        self.assertDatesIncreaseSince(data, datetime.datetime(2020, 12, 26))
+
+        def assertRow(row, expected_date, expected):
+            print(row)
+            self.assertEqual(row.date, expected_date)
+            self.assertEqual(row.pfizer, expected[0])
+            self.assertEqual(row.moderna, expected[1])
+            self.assertEqual(row.az, expected[2])
+            self.assertEqual(row.janssen, expected[3])
+
+        assertRow(data[10], datetime.datetime(2021, 1, 6), [5285, None, None, None])
+        assertRow(data[126], datetime.datetime(2021, 5, 7), [15972, 934, 3436, 777])

--- a/test/test.py
+++ b/test/test.py
@@ -65,6 +65,7 @@ class CepimoseTestCase(unittest.TestCase):
             self.assertGreater(data[grp].share_first, 0)
             self.assertGreater(data[grp].count_second, 0)
             self.assertGreater(data[grp].share_second, 0)
+            self.assertGreaterEqual(data[grp].count_first, data[grp].count_second)
 
     def test_vaccinations_by_region(self):
         # Test feature one.


### PR DESCRIPTION
It's a DRAFT.

Crurrently used by [data/update_vaccination.py](https://github.com/sledilnik/data/blob/master/update_vaccination.py):
* [x] vaccinations_by_day()
* [x] vaccines_supplied_by_manufacturer()
* [ ] vaccinations_by_manufacturer_supplied_used()
* [x] vaccinations_by_age()
* [x] vaccinations_by_region_by_day()
* [x] vaccinations_by_municipalities_share()

Set up a test PR https://github.com/sledilnik/data/pull/132 to test the changes: [![Vaccination update](https://github.com/sledilnik/data/actions/workflows/vaccination.yml/badge.svg?branch=cepimose-fix-after-nijz-change)](https://github.com/sledilnik/data/actions/workflows/vaccination.yml?query=branch%3Acepimose-fix-after-nijz-change)